### PR TITLE
Merge bug fixes from jupyterhub-nbgrader-brsu/swi/swipl_kernel.py

### DIFF
--- a/swipl_kernel.py
+++ b/swipl_kernel.py
@@ -9,6 +9,7 @@ from backports import tempfile
 def exec_swipl(code):
     temp_path, output_path, code_path = setup_env()
     ''' Parser code begins here '''
+    
     preCode1 = 'doa([]).\n\n' 
     preCode2 = 'doa( [G|_] ) :-  write(\' \\n----------------------------------------- \\n Call of: \\t \'), write(G), call(G), write(\' \\n TRUE with:\\t \'), write(G), fail.\n\n'
     preCode3 = 'doa( [G|R] ) :- not(G), !, write(\' \\n FALSE!  \\t \'), write(G), doa(R).\n\n'
@@ -19,13 +20,14 @@ def exec_swipl(code):
     with open(temp_path, 'w') as f: # 
         f.write(code)
     
+    
     textlist = []
     textlist.append(preCode1)
     textlist.append(preCode2)
     textlist.append(preCode3)
     textlist.append(preCode4)
     textlist.append(emptyline)
-
+    
     with open(temp_path) as f: 
         ''' 
         some hacky logic to enable students to simply add queries
@@ -42,11 +44,12 @@ def exec_swipl(code):
     print(''.join(textlist))
     with open(code_path, 'w') as rules:
         rules.write(''.join(textlist))
+    tmp_dir = tempfile.mkdtemp()
     code2_path = op.join(tmp_dir, 'code2.pl')
     with open(code_path, 'w') as rules:
          rules.write(''.join(textlist))
-
-    os.system("swipl {0:s} > {1:s}  2>&1 ".format(code_path, output_path))  
+    
+    os.system("swipl {0:s} > {1:s}  2>&1 ".format(code_path, output_path))
     f = open(output_path, 'r')
     return f.read()
 
@@ -56,7 +59,7 @@ def setup_env():
     temp_path = op.join(dirpath, 'temp.pl')
     output_path = op.join(dirpath, 'out.txt')
     code_path = op.join(dirpath, 'code.pl')
-    return temp_path, output_path, code_path 
+    return temp_path, output_path, code_path
 
 """SWI-Prolog kernel wrapper"""
 from ipykernel.kernelbase import Kernel


### PR DESCRIPTION
Die Variable `tmp_dir` war nicht zugewiesen. Aber offenbar ist auch das nicht die neueste Kernel Version, denn hierbei wird immer `Welcome to SWI-Prolog (threaded, 64 bits, version 7.6.4) ...` ausgegeben?!?